### PR TITLE
Fix various TE crashes during rendering.

### DIFF
--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/BlenderRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/BlenderRenderer.java
@@ -22,20 +22,17 @@ import org.lwjgl.opengl.GL11;
 import com.mrcrayfish.furniture.tileentity.TileEntityBlender;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 
-public class BlenderRenderer extends TileEntitySpecialRenderer
+public class BlenderRenderer extends TileEntitySpecialRenderer<TileEntityBlender>
 {
 	private EntityItem entityFood = new EntityItem(Minecraft.getMinecraft().theWorld, 0D, 0D, 0D);
 
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityBlender blender, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{
-		TileEntityBlender blender = (TileEntityBlender) tileEntity;
 		ItemStack[] ingredients = blender.getIngredients();
 
 		GL11.glPushMatrix();
@@ -56,7 +53,6 @@ public class BlenderRenderer extends TileEntitySpecialRenderer
 
 		if (blender.isBlending() | blender.drinkCount > 0)
 		{
-			Tessellator tessellator = Tessellator.getInstance();
 			GL11.glPushMatrix();
 			GL11.glTranslatef((float) posX + 0.5F, (float) posY + 0.05F, (float) posZ + 0.5F);
 			GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);

--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/ChoppingBoardRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/ChoppingBoardRenderer.java
@@ -19,30 +19,20 @@ package com.mrcrayfish.furniture.render.tileentity;
 
 import org.lwjgl.opengl.GL11;
 
-import com.mrcrayfish.furniture.blocks.BlockChoppingBoard;
 import com.mrcrayfish.furniture.tileentity.TileEntityChoppingBoard;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.item.EntityItem;
-import net.minecraft.tileentity.TileEntity;
 
-public class ChoppingBoardRenderer extends TileEntitySpecialRenderer
+public class ChoppingBoardRenderer extends TileEntitySpecialRenderer<TileEntityChoppingBoard>
 {
 	private EntityItem entityFood = new EntityItem(Minecraft.getMinecraft().theWorld, 0D, 0D, 0D);
 
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityChoppingBoard board, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{
-		Block block = tileEntity.getBlockType();
-		if(!(block instanceof BlockChoppingBoard))
-			return;
-		
-		TileEntityChoppingBoard board = (TileEntityChoppingBoard) tileEntity;
-		int metadata = block.getMetaFromState(tileEntity.getWorld().getBlockState(tileEntity.getPos()));
+		int metadata = board.getBlockMetadata();
 
 		if (board.getFood() != null)
 		{
@@ -73,7 +63,7 @@ public class ChoppingBoardRenderer extends TileEntitySpecialRenderer
 			}
 			
 			GL11.glDisable(GL11.GL_LIGHTING);
-			WorldRenderer renderer = Tessellator.getInstance().getWorldRenderer();
+			//WorldRenderer renderer = Tessellator.getInstance().getWorldRenderer();
 			//renderer.setBrightness(15728880);
 
 			GL11.glTranslatef((float) posX + 0.5F + xOffset, (float) posY + 0.02F, (float) posZ + 0.3F + zOffset);

--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/CookieRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/CookieRenderer.java
@@ -18,29 +18,25 @@
 package com.mrcrayfish.furniture.render.tileentity;
 
 import org.lwjgl.opengl.GL11;
-
-import net.minecraft.block.Block;
+import com.mrcrayfish.furniture.tileentity.TileEntityCookieJar;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 
-public class CookieRenderer extends TileEntitySpecialRenderer
+public class CookieRenderer extends TileEntitySpecialRenderer<TileEntityCookieJar>
 {
 	private ItemStack cookie = new ItemStack(Items.cookie);
 	private EntityItem entityItem = new EntityItem(Minecraft.getMinecraft().theWorld, 0D, 0D, 0D, cookie);
 
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityCookieJar cookieJar, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{	
 		GL11.glPushMatrix();
 		
 		GL11.glDisable(GL11.GL_LIGHTING);
-		WorldRenderer renderer = Tessellator.getInstance().getWorldRenderer();
+		//WorldRenderer renderer = Tessellator.getInstance().getWorldRenderer();
 		//renderer.setBrightness(15728880);
 		
 		this.entityItem.hoverStart = 0.0F;
@@ -48,11 +44,8 @@ public class CookieRenderer extends TileEntitySpecialRenderer
 		GL11.glRotatef(180, 0, 1, 1);
 		GL11.glScalef(0.9F, 0.9F, 0.9F);
 		
-		Block block = tileEntity.getBlockType();
-		if(block.isAir(getWorld(), tileEntity.getPos()))
-			return;
 
-		int metadata = block.getMetaFromState(tileEntity.getWorld().getBlockState(tileEntity.getPos()));
+		int metadata = cookieJar.getBlockMetadata();
 		for (int i = 0; i < metadata; i++)
 		{
 			Minecraft.getMinecraft().getRenderManager().renderEntityWithPosYaw(entityItem, 0.0D, 0.0D, 0.1D * i, 0.0F, 0.0F);

--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/CupRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/CupRenderer.java
@@ -21,20 +21,16 @@ import org.lwjgl.opengl.GL11;
 
 import com.mrcrayfish.furniture.tileentity.TileEntityCup;
 
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
-import net.minecraft.tileentity.TileEntity;
 
-public class CupRenderer extends TileEntitySpecialRenderer
+public class CupRenderer extends TileEntitySpecialRenderer<TileEntityCup>
 {
 
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityCup tileEntityCup, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{
-		TileEntityCup tileEntityCup = (TileEntityCup) tileEntity;
 		if (tileEntityCup.getDrink() != null)
 		{
-			Tessellator tessellator = Tessellator.getInstance();
 			GL11.glPushMatrix();
 			{
 				GL11.glTranslatef((float) posX + 0.5F, (float) posY, (float) posZ + 0.5F);

--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/MicrowaveRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/MicrowaveRenderer.java
@@ -19,28 +19,20 @@ package com.mrcrayfish.furniture.render.tileentity;
 
 import org.lwjgl.opengl.GL11;
 
-import com.mrcrayfish.furniture.blocks.BlockMicrowave;
 import com.mrcrayfish.furniture.tileentity.TileEntityMicrowave;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.item.EntityItem;
-import net.minecraft.tileentity.TileEntity;
 
-public class MicrowaveRenderer extends TileEntitySpecialRenderer
+public class MicrowaveRenderer extends TileEntitySpecialRenderer<TileEntityMicrowave>
 {
 	private EntityItem entityFood = new EntityItem(Minecraft.getMinecraft().theWorld, 0D, 0D, 0D);
 
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityMicrowave microwave, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{
-		Block block = tileEntity.getBlockType();
-		if(!(block instanceof BlockMicrowave))
-			return;
-		
-		TileEntityMicrowave microwave = (TileEntityMicrowave) tileEntity;
-		int metadata = block.getMetaFromState(tileEntity.getWorld().getBlockState(tileEntity.getPos()));
+		int metadata = microwave.getBlockMetadata();
 		
 		if (microwave.getItem() != null)
 		{

--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/MirrorRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/MirrorRenderer.java
@@ -25,12 +25,11 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.settings.GameSettings;
 import net.minecraft.entity.Entity;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
-public class MirrorRenderer extends TileEntitySpecialRenderer
+public class MirrorRenderer extends TileEntitySpecialRenderer<TileEntityMirror>
 {
 	private static Minecraft mc = Minecraft.getMinecraft();
 	public static RenderGlobal mirrorGlobalRenderer = new MirrorRenderGlobal(mc);
@@ -52,55 +51,53 @@ public class MirrorRenderer extends TileEntitySpecialRenderer
 	}
 
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityMirror mirror, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{
 		if(!ConfigurationHandler.mirrorEnabled)
 			return;
 		
 		if(TileEntityRendererDispatcher.instance.entity instanceof EntityMirror)
 			return;
-		
-		TileEntityMirror mirror = (TileEntityMirror) tileEntity;
-		IBlockState state = tileEntity.getWorld().getBlockState(tileEntity.getPos());
-		if (state.getBlock() instanceof BlockMirror)
-		{
-			if (!registerMirrors.containsKey(mirror.getMirror()))
-			{
-				int newTextureId = GL11.glGenTextures();
-				GlStateManager.bindTexture(newTextureId);
-				GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGB, quality, quality, 0, GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, BufferUtils.createByteBuffer(3 * quality * quality));
-				GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
-				GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
-				registerMirrors.put(mirror.getMirror(), newTextureId);
-				return;
-			}
-			
-			((EntityMirror)mirror.getMirror()).rendering = true;
 
-			EnumFacing facing = (EnumFacing) state.getValue(BlockMirror.FACING);
-			GlStateManager.pushMatrix();
-			{
-				GlStateManager.disableLighting();
-				GlStateManager.bindTexture(registerMirrors.get(mirror.getMirror()).intValue());
-				GlStateManager.translate((float) posX + 0.5F, (float) posY, (float) posZ + 0.5F);
-				GlStateManager.rotate(-90F * facing.getHorizontalIndex() + 180F, 0, 1, 0);
-				GlStateManager.translate(-0.5F, 0, -0.43F);
-				GL11.glBegin(GL11.GL_QUADS);
-				{
-					GL11.glTexCoord2d(1, 0);
-					GL11.glVertex3d(0.0625, 0.0625, 0);
-					GL11.glTexCoord2d(0, 0);
-					GL11.glVertex3d(0.9375, 0.0625, 0);
-					GL11.glTexCoord2d(0, 1);
-					GL11.glVertex3d(0.9375, 0.9375, 0);
-					GL11.glTexCoord2d(1, 1);
-					GL11.glVertex3d(0.0625, 0.9375, 0);
-				}
-				GL11.glEnd();
-				GlStateManager.enableLighting();
-			}
-			GlStateManager.popMatrix();
+		IBlockState state = mirror.getWorld().getBlockState(mirror.getPos());
+		if(!(state.getBlock() instanceof BlockMirror))
+			return;
+
+		if (!registerMirrors.containsKey(mirror.getMirror()))
+		{
+			int newTextureId = GL11.glGenTextures();
+			GlStateManager.bindTexture(newTextureId);
+			GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGB, quality, quality, 0, GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, BufferUtils.createByteBuffer(3 * quality * quality));
+			GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
+			GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
+			registerMirrors.put(mirror.getMirror(), newTextureId);
+			return;
 		}
+
+		((EntityMirror)mirror.getMirror()).rendering = true;
+		EnumFacing facing = (EnumFacing) state.getValue(BlockMirror.FACING);
+		GlStateManager.pushMatrix();
+		{
+			GlStateManager.disableLighting();
+			GlStateManager.bindTexture(registerMirrors.get(mirror.getMirror()).intValue());
+			GlStateManager.translate((float) posX + 0.5F, (float) posY, (float) posZ + 0.5F);
+			GlStateManager.rotate(-90F * facing.getHorizontalIndex() + 180F, 0, 1, 0);
+			GlStateManager.translate(-0.5F, 0, -0.43F);
+			GL11.glBegin(GL11.GL_QUADS);
+			{
+				GL11.glTexCoord2d(1, 0);
+				GL11.glVertex3d(0.0625, 0.0625, 0);
+				GL11.glTexCoord2d(0, 0);
+				GL11.glVertex3d(0.9375, 0.0625, 0);
+				GL11.glTexCoord2d(0, 1);
+				GL11.glVertex3d(0.9375, 0.9375, 0);
+				GL11.glTexCoord2d(1, 1);
+				GL11.glVertex3d(0.0625, 0.9375, 0);
+			}
+			GL11.glEnd();
+			GlStateManager.enableLighting();
+		}
+		GlStateManager.popMatrix();
 	}
 
 	@SubscribeEvent

--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/OvenRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/OvenRenderer.java
@@ -9,16 +9,16 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 
-public class OvenRenderer extends TileEntitySpecialRenderer
+public class OvenRenderer extends TileEntitySpecialRenderer<TileEntityOven>
 {
 	private EntityItem ovenItem = new EntityItem(Minecraft.getMinecraft().theWorld, 0D, 0D, 0D);
 
-	private int counter = 0;
+	@SuppressWarnings("unused")
+    private int counter = 0;
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityOven oven, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{
 		//TODO Make alternaltive
 		/*if(counter++ == 10)
@@ -37,7 +37,6 @@ public class OvenRenderer extends TileEntitySpecialRenderer
 			GlStateManager.translate(posX + 0.3, posY + 0.52, posZ + 0.5);
 			GlStateManager.scale(0.66, 0.66, 0.66);
 
-			TileEntityOven oven = (TileEntityOven) tileEntity;
 			for (int i = 0; i < oven.getSizeInventory(); i++)
 			{
 				double height = (i / 4) * -0.25D;

--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/PlateRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/PlateRenderer.java
@@ -22,20 +22,16 @@ import org.lwjgl.opengl.GL11;
 import com.mrcrayfish.furniture.tileentity.TileEntityPlate;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.item.EntityItem;
-import net.minecraft.tileentity.TileEntity;
 
-public class PlateRenderer extends TileEntitySpecialRenderer
+public class PlateRenderer extends TileEntitySpecialRenderer<TileEntityPlate>
 {
 	private EntityItem entityFood = new EntityItem(Minecraft.getMinecraft().theWorld, 0D, 0D, 0D);
 
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityPlate plate, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{
-		TileEntityPlate plate = (TileEntityPlate) tileEntity;
 		if (plate.getFood() != null)
 		{
 			entityFood.setEntityItemStack(plate.getFood());
@@ -65,7 +61,7 @@ public class PlateRenderer extends TileEntitySpecialRenderer
 			}
 			
 			GL11.glDisable(GL11.GL_LIGHTING);
-			WorldRenderer renderer = Tessellator.getInstance().getWorldRenderer();
+			//WorldRenderer renderer = Tessellator.getInstance().getWorldRenderer();
 			//renderer.setBrightness(15728880);
 
 			GL11.glTranslatef((float) posX + 0.5F + xOffset, (float) posY + 0.05F, (float) posZ + 0.3F + zOffset);

--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/ToastRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/ToastRenderer.java
@@ -21,27 +21,19 @@ import org.lwjgl.opengl.GL11;
 
 import com.mrcrayfish.furniture.tileentity.TileEntityToaster;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 
-public class ToastRenderer extends TileEntitySpecialRenderer
+public class ToastRenderer extends TileEntitySpecialRenderer<TileEntityToaster>
 {
 	private EntityItem[] slots = { new EntityItem(Minecraft.getMinecraft().theWorld, 0D, 0D, 0D), new EntityItem(Minecraft.getMinecraft().theWorld, 0D, 0D, 0D) };
 
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityToaster tileEntityToaster, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{
-		TileEntityToaster tileEntityToaster = (TileEntityToaster) tileEntity;
-		
-		Block block = tileEntity.getBlockType();
-		if(block.isAir(getWorld(), tileEntity.getPos()))
-			return;
-		
-		int metadata = block.getMetaFromState(tileEntity.getWorld().getBlockState(tileEntity.getPos()));
+		int metadata = tileEntityToaster.getBlockMetadata();
 
 		for (int i = 0; i < 2; i++)
 		{

--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/TreeRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/TreeRenderer.java
@@ -7,21 +7,17 @@ import com.mrcrayfish.furniture.tileentity.TileEntityTree;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 
-public class TreeRenderer extends TileEntitySpecialRenderer
+public class TreeRenderer extends TileEntitySpecialRenderer<TileEntityTree>
 {
 	private EntityItem ornament = new EntityItem(Minecraft.getMinecraft().theWorld, 0D, 0D, 0D);
 
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityTree tree, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{
-		TileEntityTree tree = (TileEntityTree) tileEntity;
 		Block block = tree.getWorld().getBlockState(tree.getPos()).getBlock();
 		
 		float yOffset = 0.0F;
@@ -48,7 +44,7 @@ public class TreeRenderer extends TileEntitySpecialRenderer
 				GL11.glPushMatrix();
 				
 				GL11.glDisable(GL11.GL_LIGHTING);
-				WorldRenderer renderer = Tessellator.getInstance().getWorldRenderer();
+				//WorldRenderer renderer = Tessellator.getInstance().getWorldRenderer();
 				//renderer.setBrightness(15728880);
 
 				GL11.glRotatef(-90 * i, 0, 1, 0);

--- a/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/WashingMachineRenderer.java
+++ b/1.8.9/src/main/java/com/mrcrayfish/furniture/render/tileentity/WashingMachineRenderer.java
@@ -19,30 +19,23 @@ package com.mrcrayfish.furniture.render.tileentity;
 
 import org.lwjgl.opengl.GL11;
 
-import com.mrcrayfish.furniture.blocks.BlockWashingMachine;
 import com.mrcrayfish.furniture.tileentity.TileEntityWashingMachine;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.item.EntityItem;
-import net.minecraft.tileentity.TileEntity;
 
-public class WashingMachineRenderer extends TileEntitySpecialRenderer
+public class WashingMachineRenderer extends TileEntitySpecialRenderer<TileEntityWashingMachine>
 {
 	private EntityItem armour = new EntityItem(Minecraft.getMinecraft().theWorld, 0D, 0D, 0D);
 	
-	private int counter = 0;
+	@SuppressWarnings("unused")
+    private int counter = 0;
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tileEntity, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
+	public void renderTileEntityAt(TileEntityWashingMachine machine, double posX, double posY, double posZ, float p_180535_8_, int p_180535_9_)
 	{
-		Block block = tileEntity.getBlockType();
-		if(!(block instanceof BlockWashingMachine))
-			return;
-		
-		TileEntityWashingMachine machine = (TileEntityWashingMachine) tileEntity;
-		int metadata = block.getMetaFromState(tileEntity.getWorld().getBlockState(tileEntity.getPos()));
+		int metadata = machine.getBlockMetadata();
 
 		GL11.glPushMatrix();
 		GL11.glTranslatef((float) posX + 0.5F, (float) posY + 0.5F, (float) posZ + 0.5F);


### PR DESCRIPTION
There is some odd vanilla or Forge bug that causes the TESR to randomly receive AIR when getting the blockstate.

* Update TE renderers with generics which has been supported since 1.8.8.
* Clean up some code.

This PR fixes issue #45