### PR TITLE
Fix BlockBlinds picking & dropping wrong block

### DIFF
--- a/1.8/src/main/java/com/mrcrayfish/furniture/blocks/BlockBlinds.java
+++ b/1.8/src/main/java/com/mrcrayfish/furniture/blocks/BlockBlinds.java
@@ -106,13 +106,13 @@ public class BlockBlinds extends BlockFurniture
 	@Override
 	public Item getItemDropped(IBlockState state, Random rand, int fortune)
 	{
-		return new ItemStack(FurnitureBlocks.blinds_closed).getItem();
+		return new ItemStack(FurnitureBlocks.blinds).getItem();
 	}
 
 	@Override
 	public ItemStack getPickBlock(MovingObjectPosition target, World world, BlockPos pos)
 	{
-		return new ItemStack(FurnitureBlocks.blinds_closed);
+		return new ItemStack(FurnitureBlocks.blinds);
 	}
 	
 	@Override


### PR DESCRIPTION
Currently dropping the "closed" version, which lacks rendering and doesn't stack with the default, crafted version.