### PR TITLE
CraftTweaker Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,14 @@ minecraft {
     mappings = "snapshot_20171003"
 }
 
+repositories {
+    maven { url "http://maven.blamejared.com/" } // CraftTweaker
+}
+
+dependencies {
+    deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.6.467"
+}
+
 processResources {
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version

--- a/src/main/java/com/mrcrayfish/furniture/MrCrayfishFurnitureMod.java
+++ b/src/main/java/com/mrcrayfish/furniture/MrCrayfishFurnitureMod.java
@@ -32,6 +32,7 @@ import com.mrcrayfish.furniture.handler.PlayerEvents;
 import com.mrcrayfish.furniture.init.FurnitureTab;
 import com.mrcrayfish.furniture.init.FurnitureTileEntities;
 import com.mrcrayfish.furniture.init.RegistrationHandler;
+import com.mrcrayfish.furniture.integration.crafttweaker.CraftTweakerIntegration;
 import com.mrcrayfish.furniture.network.PacketHandler;
 import com.mrcrayfish.furniture.proxy.CommonProxy;
 import com.mrcrayfish.furniture.render.tileentity.MirrorRenderer;
@@ -55,7 +56,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Method;
 
-@Mod(modid = Reference.MOD_ID, name = Reference.NAME, version = Reference.VERSION, guiFactory = Reference.GUI_FACTORY_CLASS, acceptedMinecraftVersions = Reference.ACCEPTED_MC_VERSIONS)
+@Mod(modid = Reference.MOD_ID, name = Reference.NAME, version = Reference.VERSION, dependencies = Reference.DEPENDENCIES, guiFactory = Reference.GUI_FACTORY_CLASS, acceptedMinecraftVersions = Reference.ACCEPTED_MC_VERSIONS)
 public class MrCrayfishFurnitureMod
 {
     @Instance(Reference.MOD_ID)
@@ -123,6 +124,11 @@ public class MrCrayfishFurnitureMod
         RecipeRegistry.registerDefaultRecipes();
         RecipeRegistry.registerConfigRecipes();
         Recipes.addCommRecipesToLocal();
+        /* Craft Tweaker Integration */
+        if (Loader.isModLoaded("crafttweaker"))
+        {
+            CraftTweakerIntegration.apply();
+        }
         Recipes.updateDataList();
 
         Channels.registerChannels();

--- a/src/main/java/com/mrcrayfish/furniture/Reference.java
+++ b/src/main/java/com/mrcrayfish/furniture/Reference.java
@@ -23,6 +23,7 @@ public class Reference
     public static final String NAME = "MrCrayfish's Furniture Mod";
     public static final String VERSION = "5.2.1";
     public static final String ACCEPTED_MC_VERSIONS = "[1.12.2]";
+    public static final String DEPENDENCIES = "after:crafttweaker";
     public static final String CLIENT_PROXY_CLASS = "com.mrcrayfish.furniture.proxy.ClientProxy";
     public static final String SERVER_PROXY_CLASS = "com.mrcrayfish.furniture.proxy.CommonProxy";
     public static final String GUI_FACTORY_CLASS = "com.mrcrayfish.furniture.gui.GuiFactory";

--- a/src/main/java/com/mrcrayfish/furniture/handler/ConfigurationHandler.java
+++ b/src/main/java/com/mrcrayfish/furniture/handler/ConfigurationHandler.java
@@ -25,8 +25,10 @@ import com.mrcrayfish.furniture.api.Recipes;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import com.mrcrayfish.furniture.integration.crafttweaker.CraftTweakerIntegration;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class ConfigurationHandler
@@ -95,6 +97,11 @@ public class ConfigurationHandler
             RecipeRegistry.registerDefaultRecipes();
             RecipeRegistry.registerConfigRecipes();
             Recipes.addCommRecipesToLocal();
+            /** Craft Tweaker Integration **/
+            if (Loader.isModLoaded("crafttweaker"))
+            {
+                CraftTweakerIntegration.apply();
+            }
             Recipes.updateDataList();
         }
         config.save();

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Blender.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Blender.java
@@ -1,0 +1,131 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.google.common.base.Predicates;
+import com.mrcrayfish.furniture.api.RecipeData;
+import com.mrcrayfish.furniture.api.Recipes;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import net.minecraft.item.ItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.function.Predicate;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "Blender")
+public class Blender {
+    @ZenMethod
+    @ZenDoc("Remove matching blended drinks.")
+    public static void remove(@Optional final String name, @Optional final IItemStack[] ingredients, @Optional final Integer food, @Optional final int[] colour) {
+        final StringBuilder description = new StringBuilder();
+        Predicate<RecipeData> matcher = Predicates.alwaysTrue();
+
+        boolean first = true;
+
+        description.append("Remove drink(s) matching '");
+
+        if (name != null) {
+            matcher = matcher.and((data) -> data.getDrinkName().equals(name));
+            if (first) first = false;
+            else description.append(',');
+            description.append("name=" + name);
+        }
+
+        if (ingredients != null) {
+            matcher = matcher.and((data) -> {
+                if (data.getIngredients().size() != ingredients.length) return false;
+                LinkedList<IItemStack> toCheck = new LinkedList<>();
+
+                for (IItemStack checker : ingredients) toCheck.add(checker);
+
+                outer:
+                for (ItemStack stack : data.getIngredients()) {
+                    for (Iterator<IItemStack> it = toCheck.iterator(); it.hasNext(); ) {
+                        IItemStack checker = it.next();
+                        if (CraftTweakerMC.matchesExact(checker, stack)) {
+                            it.remove();
+                            continue outer;
+                        }
+                    }
+                    return false;
+                }
+                return true;
+            });
+            if (first) first = false;
+            else description.append(',');
+            description.append("ingredients=" + Arrays.toString(ingredients));
+        }
+
+        if (food != null) {
+            matcher = matcher.and((data) -> data.getHealAmount() == food);
+            if (first) first = false;
+            else description.append(',');
+            description.append("food=" + food);
+        }
+
+        if (colour != null) {
+            if (colour.length != 3) throw new IllegalArgumentException("colour must have 3 components");
+            for (int c : colour)
+                if (c < 0 || c > 255)
+                    throw new IllegalArgumentException("colour components must be between 0 and 255 inclusive");
+            matcher = matcher.and((data) -> data.getRed() == colour[0] && data.getGreen() == colour[1] && data.getBlue() == colour[2]);
+            if (first) first = false;
+            else description.append(',');
+            description.append("colour=" + Arrays.toString(colour));
+        }
+
+        description.append("' from Blender");
+
+        if (first) {
+            description.setLength(0);
+            description.append("Remove all drinks from Blender");
+        }
+
+        final Predicate<RecipeData> finalMatcher = matcher;
+        CraftTweakerIntegration.defer(description.toString(), () -> {
+            if (!Recipes.localBlenderRecipes.removeIf((data) -> {
+                if (finalMatcher.test(data)) {
+                    CraftTweakerAPI.logInfo("Blender: Removed blended drink " + data);
+                    return true;
+                }
+                return false;
+            })) {
+                CraftTweakerAPI.logError("Blender: No blended drinks matched");
+            }
+        });
+    }
+
+    @ZenMethod
+    @ZenDoc("Add a blended drink.")
+    public static void addDrink(@Nonnull final String name, @Nonnull final IItemStack[] ingredients, final int food, @Nonnull final int[] colour) {
+        if (name == null) throw new IllegalArgumentException("name cannot be null");
+        if (ingredients == null) throw new IllegalArgumentException("ingredients cannot be null");
+        if (food < 0) throw new IllegalArgumentException("food value must be non-negative");
+        if (colour == null) throw new IllegalArgumentException("colour cannot be null");
+        if (colour.length != 3) throw new IllegalArgumentException("colour must have 3 components");
+        for (int c : colour)
+            if (c < 0 || c > 255)
+                throw new IllegalArgumentException("colour components must be between 0 and 255 inclusive");
+
+        final RecipeData data = new RecipeData();
+        data.setName(name);
+        for (IItemStack i : ingredients) {
+            data.addIngredient(CraftTweakerMC.getItemStack(i));
+        }
+        data.setHeal(food);
+        data.setColour(colour[0], colour[1], colour[2]);
+
+        CraftTweakerIntegration.defer("Add blended drink " + data + " to Blender", () -> {
+            Recipes.localBlenderRecipes.add(data);
+            CraftTweakerAPI.logInfo("Blender: Added trade " + data);
+        });
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/ChoppingBoard.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/ChoppingBoard.java
@@ -1,0 +1,31 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.mrcrayfish.furniture.api.Recipes;
+import com.mrcrayfish.furniture.integration.crafttweaker.helpers.OneToOneRecipes;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "ChoppingBoard")
+public class ChoppingBoard {
+    private static final OneToOneRecipes recipes = new OneToOneRecipes("ChoppingBoard", Recipes.localChoppingBoardRecipes);
+
+    @ZenMethod
+    @ZenDoc("Remove matching chopping recipes.")
+    public static void remove(@Optional final IIngredient output, @Optional final IIngredient input) {
+        recipes.remove(output, input);
+    }
+
+    @ZenMethod
+    @ZenDoc("Add a chopping recipe.")
+    public static void addRecipe(@Nonnull final IItemStack output, @Nonnull final IItemStack input) {
+        recipes.addRecipe(output, input);
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/CraftTweakerIntegration.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/CraftTweakerIntegration.java
@@ -1,0 +1,48 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.IAction;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class CraftTweakerIntegration {
+    public static final String CLASS_PREFIX = "mods.cfm.";
+
+    private static final List<IAction> ACTIONS = new LinkedList<>();
+
+    public static void defer(String description, Runnable action) {
+        ACTIONS.add(new DeferredAction(description, action));
+    }
+
+    public static void apply() {
+        CraftTweakerAPI.logInfo("Applying MrCrayfish's Furniture Mod changes...");
+        ACTIONS.forEach((action) -> {
+            try {
+                CraftTweakerAPI.apply(action);
+            } catch (Exception ex) {
+                CraftTweakerAPI.logError("Exception whilst applying \"" + action.describe() + "\"", ex);
+            }
+        });
+    }
+
+    private static class DeferredAction implements IAction {
+        private final String description;
+        private final Runnable func;
+
+        public DeferredAction(String description, Runnable func) {
+            this.description = description;
+            this.func = func;
+        }
+
+        @Override
+        public void apply() {
+            func.run();
+        }
+
+        @Override
+        public String describe() {
+            return description;
+        }
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Dishwasher.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Dishwasher.java
@@ -1,0 +1,31 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.mrcrayfish.furniture.api.Recipes;
+import com.mrcrayfish.furniture.integration.crafttweaker.helpers.OneToNoneRecipes;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "Dishwasher")
+public class Dishwasher {
+    private static final OneToNoneRecipes recipes = new OneToNoneRecipes("Dishwasher", Recipes.localDishwasherRecipes);
+
+    @ZenMethod
+    @ZenDoc("Remove matching washable items.")
+    public static void remove(@Optional final IIngredient item) {
+        recipes.remove(item);
+    }
+
+    @ZenMethod
+    @ZenDoc("Add a washable item.")
+    public static void add(@Nonnull final IItemStack item) {
+        recipes.add(item);
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Freezer.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Freezer.java
@@ -1,0 +1,31 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.mrcrayfish.furniture.api.Recipes;
+import com.mrcrayfish.furniture.integration.crafttweaker.helpers.OneToOneRecipes;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "Freezer")
+public class Freezer {
+    private static final OneToOneRecipes recipes = new OneToOneRecipes("Freezer", Recipes.localFreezerRecipes);
+
+    @ZenMethod
+    @ZenDoc("Remove matching freezer recipes.")
+    public static void remove(@Optional final IIngredient output, @Optional final IIngredient input) {
+        recipes.remove(output, input);
+    }
+
+    @ZenMethod
+    @ZenDoc("Add a freezer recipe.")
+    public static void addRecipe(@Nonnull final IItemStack output, @Nonnull final IItemStack input) {
+        recipes.addRecipe(output, input);
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Grill.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Grill.java
@@ -1,0 +1,31 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.mrcrayfish.furniture.api.Recipes;
+import com.mrcrayfish.furniture.integration.crafttweaker.helpers.OneToOneRecipes;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "Grill")
+public class Grill {
+    private static final OneToOneRecipes recipes = new OneToOneRecipes("Grill", Recipes.localGrillRecipes);
+
+    @ZenMethod
+    @ZenDoc("Remove matching grill recipes.")
+    public static void remove(@Optional final IIngredient output, @Optional final IIngredient input) {
+        recipes.remove(output, input);
+    }
+
+    @ZenMethod
+    @ZenDoc("Add a grill recipe.")
+    public static void addRecipe(@Nonnull final IItemStack output, @Nonnull final IItemStack input) {
+        recipes.addRecipe(output, input);
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Microwave.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Microwave.java
@@ -1,0 +1,31 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.mrcrayfish.furniture.api.Recipes;
+import com.mrcrayfish.furniture.integration.crafttweaker.helpers.OneToOneRecipes;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "Microwave")
+public class Microwave {
+    private static final OneToOneRecipes recipes = new OneToOneRecipes("Microwave", Recipes.localMicrowaveRecipes);
+
+    @ZenMethod
+    @ZenDoc("Remove matching microwave recipes.")
+    public static void remove(@Optional final IIngredient output, @Optional final IIngredient input) {
+        recipes.remove(output, input);
+    }
+
+    @ZenMethod
+    @ZenDoc("Add a microwave recipe.")
+    public static void addRecipe(@Nonnull final IItemStack output, @Nonnull final IItemStack input) {
+        recipes.addRecipe(output, input);
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/MineBay.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/MineBay.java
@@ -1,0 +1,62 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.mrcrayfish.furniture.api.RecipeData;
+import com.mrcrayfish.furniture.api.Recipes;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.IngredientAny;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.mc1120.item.MCItemStack;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "MineBay")
+public class MineBay {
+    @ZenMethod
+    @ZenDoc("Remove matching trades.")
+    public static void remove(@Optional IIngredient item) {
+        if (item == null) item = IngredientAny.INSTANCE;
+
+        final IIngredient finalItem = item;
+        CraftTweakerIntegration.defer("Remove trade(s) matching " + item + " from MineBay", () -> {
+            if (!Recipes.localMineBayRecipes.removeIf((data) -> {
+                if (finalItem.matchesExact(new MCItemStack(data.getInput()))) {
+                    CraftTweakerAPI.logInfo("MineBay: Removed trade " + data);
+                    return true;
+                }
+                return false;
+            })) {
+                CraftTweakerAPI.logError("MineBay: No trades matched " + finalItem);
+            }
+        });
+    }
+
+    @ZenMethod
+    @ZenDoc("Add a trade. Price range 1 to 64 (default 1). Currency defaults to Emerald.")
+    public static void addTrade(@Nonnull IItemStack item, @Optional Integer price, @Optional IItemStack currency) {
+        if (item == null) throw new IllegalArgumentException("item cannot be null");
+
+        final RecipeData data = new RecipeData();
+        data.setInput(CraftTweakerMC.getItemStack(item));
+        data.setPrice(price == null ? 1 : price);
+        data.setCurrency(currency == null ? new ItemStack(Items.EMERALD) : CraftTweakerMC.getItemStack(currency));
+
+        CraftTweakerIntegration.defer("Add trade " + data + " to MineBay", () -> {
+            if (data.getPrice() < 1 || data.getPrice() > 64) {
+                CraftTweakerAPI.logError("MineBay: Invalid trade price. Must be from 1 to 64.");
+                return;
+            }
+            Recipes.localMineBayRecipes.add(data);
+            CraftTweakerAPI.logInfo("MineBay: Added trade " + data);
+        });
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/MineBay.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/MineBay.java
@@ -41,14 +41,17 @@ public class MineBay {
     }
 
     @ZenMethod
-    @ZenDoc("Add a trade. Price range 1 to 64 (default 1). Currency defaults to Emerald.")
-    public static void addTrade(@Nonnull IItemStack item, @Optional Integer price, @Optional IItemStack currency) {
+    @ZenDoc("Add a trade.")
+    public static void addTrade(@Nonnull IItemStack item, @Nonnull IItemStack currency) {
         if (item == null) throw new IllegalArgumentException("item cannot be null");
+        if (currency == null ) throw new IllegalArgumentException("currency cannot be null");
 
         final RecipeData data = new RecipeData();
+        // MineBay RecipeData uses setInput for the purchasable item
         data.setInput(CraftTweakerMC.getItemStack(item));
-        data.setPrice(price == null ? 1 : price);
-        data.setCurrency(currency == null ? new ItemStack(Items.EMERALD) : CraftTweakerMC.getItemStack(currency));
+        // MineBar RecipeData uses setCurrency for the currency item and setPrice for the amount of that item
+        data.setCurrency(CraftTweakerMC.getItemStack(currency.withAmount(1)));
+        data.setPrice(currency.getAmount());
 
         CraftTweakerIntegration.defer("Add trade " + data + " to MineBay", () -> {
             if (data.getPrice() < 1 || data.getPrice() > 64) {

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Oven.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Oven.java
@@ -1,0 +1,31 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.mrcrayfish.furniture.api.Recipes;
+import com.mrcrayfish.furniture.integration.crafttweaker.helpers.OneToOneRecipes;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "Oven")
+public class Oven {
+    private static final OneToOneRecipes recipes = new OneToOneRecipes("Oven", Recipes.localOvenRecipes);
+
+    @ZenMethod
+    @ZenDoc("Remove matching oven recipes.")
+    public static void remove(@Optional final IIngredient output, @Optional final IIngredient input) {
+        recipes.remove(output, input);
+    }
+
+    @ZenMethod
+    @ZenDoc("Add an oven recipe.")
+    public static void addRecipe(@Nonnull final IItemStack output, @Nonnull final IItemStack input) {
+        recipes.addRecipe(output, input);
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Printer.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Printer.java
@@ -1,0 +1,31 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.mrcrayfish.furniture.api.Recipes;
+import com.mrcrayfish.furniture.integration.crafttweaker.helpers.OneToNoneRecipes;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "Printer")
+public class Printer {
+    private static final OneToNoneRecipes recipes = new OneToNoneRecipes("Printer", Recipes.localPrinterRecipes);
+
+    @ZenMethod
+    @ZenDoc("Remove matching printable items.")
+    public static void remove(@Optional final IIngredient item) {
+        recipes.remove(item);
+    }
+
+    @ZenMethod
+    @ZenDoc("Add printable item.")
+    public static void add(@Nonnull final IItemStack item) {
+        recipes.add(item);
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Toaster.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/Toaster.java
@@ -1,0 +1,31 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.mrcrayfish.furniture.api.Recipes;
+import com.mrcrayfish.furniture.integration.crafttweaker.helpers.OneToOneRecipes;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "Toaster")
+public class Toaster {
+    private static final OneToOneRecipes recipes = new OneToOneRecipes("Toaster", Recipes.localToasterRecipes);
+
+    @ZenMethod
+    @ZenDoc("Remove matching toaster recipes.")
+    public static void remove(@Optional final IIngredient output, @Optional final IIngredient input) {
+        recipes.remove(output, input);
+    }
+
+    @ZenMethod
+    @ZenDoc("Add a toaster recipe.")
+    public static void addRecipe(@Nonnull final IItemStack output, @Nonnull final IItemStack input) {
+        recipes.addRecipe(output, input);
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/WashingMachine.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/WashingMachine.java
@@ -1,0 +1,31 @@
+package com.mrcrayfish.furniture.integration.crafttweaker;
+
+import com.mrcrayfish.furniture.api.Recipes;
+import com.mrcrayfish.furniture.integration.crafttweaker.helpers.OneToNoneRecipes;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nonnull;
+
+@ZenRegister
+@ZenClass(CraftTweakerIntegration.CLASS_PREFIX + "WashingMachine")
+public class WashingMachine {
+    private static final OneToNoneRecipes recipes = new OneToNoneRecipes("WashingMachine", Recipes.localWashingMachineRecipes);
+
+    @ZenMethod
+    @ZenDoc("Remove matching washable items.")
+    public static void remove(@Optional final IIngredient item) {
+        recipes.remove(item);
+    }
+
+    @ZenMethod
+    @ZenDoc("Add a washable item.")
+    public static void add(@Nonnull final IItemStack item) {
+        recipes.add(item);
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/helpers/OneToNoneRecipes.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/helpers/OneToNoneRecipes.java
@@ -1,0 +1,53 @@
+package com.mrcrayfish.furniture.integration.crafttweaker.helpers;
+
+import com.mrcrayfish.furniture.api.RecipeData;
+import com.mrcrayfish.furniture.integration.crafttweaker.CraftTweakerIntegration;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.IngredientAny;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.mc1120.item.MCItemStack;
+import stanhebben.zenscript.annotations.Optional;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+public class OneToNoneRecipes {
+    protected final String name;
+    protected final Collection<RecipeData> recipes;
+
+    public OneToNoneRecipes(String name, Collection<RecipeData> recipes) {
+        this.name = name;
+        this.recipes = recipes;
+    }
+
+    public void remove(@Optional IIngredient item) {
+        if (item == null) item = IngredientAny.INSTANCE;
+
+        final IIngredient finalItem = item;
+        CraftTweakerIntegration.defer("Remove item(s) matching " + item + " from " + this.name, () -> {
+            if (!this.recipes.removeIf((data) -> {
+                if (finalItem.matchesExact(new MCItemStack(data.getInput()))) {
+                    CraftTweakerAPI.logInfo(this.name + ": Removed item " + data);
+                    return true;
+                }
+                return false;
+            })) {
+                CraftTweakerAPI.logError(name + ": No item matched");
+            }
+        });
+    }
+
+    public void add(@Nonnull final IItemStack item) {
+        if (item == null) throw new IllegalArgumentException("item cannot be null");
+
+        final RecipeData data = new RecipeData();
+        data.setInput(CraftTweakerMC.getItemStack(item));
+
+        CraftTweakerIntegration.defer("Add item " + data + " to " + this.name, () -> {
+            this.recipes.add(data);
+            CraftTweakerAPI.logInfo(this.name + ": Added item " + data);
+        });
+    }
+}

--- a/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/helpers/OneToOneRecipes.java
+++ b/src/main/java/com/mrcrayfish/furniture/integration/crafttweaker/helpers/OneToOneRecipes.java
@@ -1,0 +1,57 @@
+package com.mrcrayfish.furniture.integration.crafttweaker.helpers;
+
+import com.mrcrayfish.furniture.api.RecipeData;
+import com.mrcrayfish.furniture.integration.crafttweaker.CraftTweakerIntegration;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.IngredientAny;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.mc1120.item.MCItemStack;
+import stanhebben.zenscript.annotations.Optional;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+public class OneToOneRecipes {
+    protected final String name;
+    protected final Collection<RecipeData> recipes;
+
+    public OneToOneRecipes(String name, Collection<RecipeData> recipes) {
+        this.name = name;
+        this.recipes = recipes;
+    }
+
+    public void remove(@Optional IIngredient output, @Optional IIngredient input) {
+        if (output == null) output = IngredientAny.INSTANCE;
+        if (input == null) input = IngredientAny.INSTANCE;
+        final IIngredient finalOutput = output;
+        final IIngredient finalInput = input;
+        CraftTweakerIntegration.defer("Remove recipe(s) matching " + output + " given " + input + " from " + this.name, () -> {
+            if (!this.recipes.removeIf((data) -> {
+                if (finalOutput.matchesExact(new MCItemStack(data.getOutput())) && finalInput.matchesExact(new MCItemStack(data.getInput()))) {
+                    CraftTweakerAPI.logInfo(this.name + ": Removed recipe " + data);
+                    return true;
+                }
+                return false;
+            })) {
+                CraftTweakerAPI.logError(name + ": No recipe matched");
+            }
+        });
+    }
+
+    public void addRecipe(@Nonnull final IItemStack output, @Nonnull final IItemStack input) {
+        if (output == null) throw new IllegalArgumentException("output cannot be null");
+
+        if (input == null) throw new IllegalArgumentException("input cannot be null");
+
+        final RecipeData data = new RecipeData();
+        data.setOutput(CraftTweakerMC.getItemStack(output));
+        data.setInput(CraftTweakerMC.getItemStack(input));
+
+        CraftTweakerIntegration.defer("Add recipe " + data + " to " + this.name, () -> {
+            this.recipes.add(data);
+            CraftTweakerAPI.logInfo(this.name + ": Added recipe " + data);
+        });
+    }
+}


### PR DESCRIPTION
Hi MrCrayfish,

This pull requests adds CraftTweaker support.

Here is an [example script](https://gist.github.com/BlueAgent/a104380351014e23e9871dd7accde007) to test the functionality ([screenshot](https://i.imgur.com/sEAN0sA.png))

This pull request was created to see if it is okay to continue this and for any changes required and/or suggestions made.

Regards,
BlueAgent

P.S. Love your mod.

<details>
<summary>
This is kinda off-topic but... Click for details.
</summary>

If you use "minecraft:night_vision" like spawned in potions it won't match.
It turned out this was because the potion tag is missing "minecraft:" at the start ([screenshot](https://i.imgur.com/5hQJcVm.png)):

```
ItemStack stack = new ItemStack(Items.POTIONITEM, 2);
NBTTagCompound data = new NBTTagCompound();
data.setString("Potion", "night_vision");
stack.setTagCompound(data);
```

If you create the potion like this it will set the tag correctly:

```
ItemStack stack = new ItemStack(Items.POTIONITEM, 2);
PotionUtils.addPotionToItemStack(stack, PotionTypes.NIGHT_VISION);
```
</details>