### PR TITLE
Fixed item spawn exploits

### DIFF
--- a/src/main/java/com/mrcrayfish/furniture/network/message/MessageEnvelope.java
+++ b/src/main/java/com/mrcrayfish/furniture/network/message/MessageEnvelope.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagString;
+import net.minecraft.util.EnumHand;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
@@ -42,7 +43,7 @@ public class MessageEnvelope implements IMessage, IMessageHandler<MessageEnvelop
     public IMessage onMessage(MessageEnvelope message, MessageContext ctx)
     {
         EntityPlayerMP player = ctx.getServerHandler().player;
-        ItemStack mail = message.envelope;
+        ItemStack mail = player.getHeldItem(EnumHand.MAIN_HAND);
         ItemStack signedMail = new ItemStack(FurnitureItems.ENVELOPE_SIGNED);
         signedMail.setTagCompound(mail.getTagCompound().copy());
         signedMail.setTagInfo("Author", new NBTTagString(player.getName()));

--- a/src/main/java/com/mrcrayfish/furniture/network/message/MessageEnvelope.java
+++ b/src/main/java/com/mrcrayfish/furniture/network/message/MessageEnvelope.java
@@ -44,6 +44,9 @@ public class MessageEnvelope implements IMessage, IMessageHandler<MessageEnvelop
     {
         EntityPlayerMP player = ctx.getServerHandler().player;
         ItemStack mail = player.getHeldItem(EnumHand.MAIN_HAND);
+		
+		if (mail.getItem() != FurnitureItems.ENVELOPE) return null;
+
         ItemStack signedMail = new ItemStack(FurnitureItems.ENVELOPE_SIGNED);
         signedMail.setTagCompound(mail.getTagCompound().copy());
         signedMail.setTagInfo("Author", new NBTTagString(player.getName()));

--- a/src/main/java/com/mrcrayfish/furniture/network/message/MessageMineBayBuy.java
+++ b/src/main/java/com/mrcrayfish/furniture/network/message/MessageMineBayBuy.java
@@ -65,21 +65,28 @@ public class MessageMineBayBuy implements IMessage, IMessageHandler<MessageMineB
             ItemStack buySlot = tileEntityComputer.getStackInSlot(0);
             RecipeData[] data = Recipes.getMineBayItems();
             int price = data[message.itemNum].getPrice();
-
-            if(buySlot == null) return null;
-
-            if(message.shouldClear)
+			
+			if(buySlot.isEmpty()) return null;
+			
+			if(!(data[message.itemNum].getCurrency().getItem() == buySlot.getItem())) return null;
+           
+            if (buySlot.getCount() >= price)
             {
-                tileEntityComputer.clear();
-            }
-            else
-            {
-                tileEntityComputer.takeEmeraldFromSlot(price);
+				 if(message.shouldClear)
+				{
+					tileEntityComputer.clear();
+				} 
+				else
+				{
+					tileEntityComputer.takeEmeraldFromSlot(price);
+				}
+				
+				EntityItem entityItem = new EntityItem(player.world, player.posX, player.posY + 1, player.posZ, data[message.itemNum].getInput().copy());
+				player.world.spawnEntity(entityItem);
+				Triggers.trigger(Triggers.MINEBAY_PURCHASE, player);
             }
 
-            EntityItem entityItem = new EntityItem(player.world, player.posX, player.posY + 1, player.posZ, data[message.itemNum].getInput().copy());
-            player.world.spawnEntity(entityItem);
-            Triggers.trigger(Triggers.MINEBAY_PURCHASE, player);
+            
         }
         return null;
     }

--- a/src/main/java/com/mrcrayfish/furniture/network/message/MessagePackage.java
+++ b/src/main/java/com/mrcrayfish/furniture/network/message/MessagePackage.java
@@ -5,6 +5,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagString;
+import net.minecraft.util.EnumHand;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
@@ -44,7 +45,7 @@ public class MessagePackage implements IMessage, IMessageHandler<MessagePackage,
     public IMessage onMessage(MessagePackage message, MessageContext ctx)
     {
         EntityPlayerMP player = ctx.getServerHandler().player;
-        ItemStack mail = message.package_;
+        ItemStack mail = player.getHeldItem(EnumHand.MAIN_HAND);
         ItemStack signedMail = new ItemStack(FurnitureItems.PACKAGE_SIGNED);
         signedMail.setTagCompound(mail.getTagCompound());
         signedMail.setTagInfo("Author", new NBTTagString(player.getName()));

--- a/src/main/java/com/mrcrayfish/furniture/network/message/MessagePackage.java
+++ b/src/main/java/com/mrcrayfish/furniture/network/message/MessagePackage.java
@@ -46,6 +46,9 @@ public class MessagePackage implements IMessage, IMessageHandler<MessagePackage,
     {
         EntityPlayerMP player = ctx.getServerHandler().player;
         ItemStack mail = player.getHeldItem(EnumHand.MAIN_HAND);
+		
+		if (mail.getItem() != FurnitureItems.PACKAGE) return null;
+		
         ItemStack signedMail = new ItemStack(FurnitureItems.PACKAGE_SIGNED);
         signedMail.setTagCompound(mail.getTagCompound());
         signedMail.setTagInfo("Author", new NBTTagString(player.getName()));

--- a/src/main/java/com/mrcrayfish/furniture/network/message/MessagePresentContents.java
+++ b/src/main/java/com/mrcrayfish/furniture/network/message/MessagePresentContents.java
@@ -5,6 +5,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagString;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
@@ -43,7 +44,7 @@ public class MessagePresentContents implements IMessage, IMessageHandler<Message
     public IMessage onMessage(MessagePresentContents message, MessageContext ctx)
     {
         EntityPlayerMP player = ctx.getServerHandler().player;
-        ItemStack present = message.envelope;
+        ItemStack present = player.getHeldItem(EnumHand.MAIN_HAND);
 
         ItemStack signedPresent = new ItemStack(FurnitureBlocks.PRESENT, 1, present.getMetadata());
         signedPresent.setTagCompound(present.getTagCompound());

--- a/src/main/java/com/mrcrayfish/furniture/network/message/MessagePresentContents.java
+++ b/src/main/java/com/mrcrayfish/furniture/network/message/MessagePresentContents.java
@@ -3,6 +3,7 @@ package com.mrcrayfish.furniture.network.message;
 import com.mrcrayfish.furniture.init.FurnitureBlocks;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagString;
 import net.minecraft.util.EnumHand;
@@ -45,7 +46,9 @@ public class MessagePresentContents implements IMessage, IMessageHandler<Message
     {
         EntityPlayerMP player = ctx.getServerHandler().player;
         ItemStack present = player.getHeldItem(EnumHand.MAIN_HAND);
-
+		
+		if (present.getItem() != Item.getItemFromBlock(FurnitureBlocks.PRESENT)) return null;
+		
         ItemStack signedPresent = new ItemStack(FurnitureBlocks.PRESENT, 1, present.getMetadata());
         signedPresent.setTagCompound(present.getTagCompound());
         signedPresent.setTagInfo("Author", new NBTTagString(player.getName()));


### PR DESCRIPTION
I was able to bypass the minebay payment system and spawn in items with the envelope/package/present by either intercepting plugin channel data and changing the minebay buy/item data or by using a client side modifcation to put client side only items in the slots that the server would accept.

Changes Made:
- Changed the minebay buySlot comparison to null as this would not be equal to null when no item is in place instead i've replaced it with the .isEmpty() function

- Made the server check that the minebay currency given is correct 

- Check the minebay price is over or equal to the desired amount

- Changed it so instead of the envelope/package/present getting item data from the plugin channel the server gets it from the current held item instead (this leaves certain data unused and should be refactored)