### PR TITLE
Fixed bug with player sitting logic and toilet flushing item destruction.

### DIFF
--- a/src/main/java/com/mrcrayfish/furniture/blocks/BlockToilet.java
+++ b/src/main/java/com/mrcrayfish/furniture/blocks/BlockToilet.java
@@ -78,7 +78,7 @@ public class BlockToilet extends BlockFurniture
         }
         else
         {
-            List<EntityItem> items = worldIn.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1.0D, pos.getY() + 1.0D, pos.getZ() + 1.0D).expand(1D, 1D, 1D));
+            List<EntityItem> items = worldIn.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1.0D, pos.getY() + 1.0D, pos.getZ() + 1.0D).grow(1D));
             for(EntityItem item : items)
             {
                 item.setDead();

--- a/src/main/java/com/mrcrayfish/furniture/util/SittableUtil.java
+++ b/src/main/java/com/mrcrayfish/furniture/util/SittableUtil.java
@@ -34,7 +34,7 @@ public class SittableUtil
 
     public static boolean checkForExistingEntity(World par1World, double x, double y, double z, EntityPlayer par5EntityPlayer)
     {
-        List<EntitySittableBlock> listEMB = par1World.getEntitiesWithinAABB(EntitySittableBlock.class, new AxisAlignedBB(x, y, z, x + 1.0D, y + 1.0D, z + 1.0D).expand(1D, 1D, 1D));
+        List<EntitySittableBlock> listEMB = par1World.getEntitiesWithinAABB(EntitySittableBlock.class, new AxisAlignedBB(x, y, z, x + 1.0D, y + 1.0D, z + 1.0D).grow(1D));
         for(EntitySittableBlock mount : listEMB)
         {
             if(mount.blockPosX == x && mount.blockPosY == y && mount.blockPosZ == z)
@@ -51,7 +51,7 @@ public class SittableUtil
 
     public static boolean isSomeoneSitting(World world, double x, double y, double z)
     {
-        List<EntitySittableBlock> listEMB = world.getEntitiesWithinAABB(EntitySittableBlock.class, new AxisAlignedBB(x, y, z, x + 1.0D, y + 1.0D, z + 1.0D).expand(1D, 1D, 1D));
+        List<EntitySittableBlock> listEMB = world.getEntitiesWithinAABB(EntitySittableBlock.class, new AxisAlignedBB(x, y, z, x + 1.0D, y + 1.0D, z + 1.0D).grow(1D));
         for(EntitySittableBlock mount : listEMB)
         {
             if(mount.blockPosX == x && mount.blockPosY == y && mount.blockPosZ == z)


### PR DESCRIPTION
As I've just fixed a longstanding/overlooked bug in EMB Phylogeny/ExtraBitManipulation@8a951fbd1062f5ab97cdae93843698d6ea94d3b6, I decided to check a number of GitHub repos for the same root cause. I've found it here, and this PR fixes it.

Evidently, in 1.12, the mapping for the three-parameter version of `AxisAlignedBB#expand` was changed to `AxisAlignedBB#grow`, and at the same time, `AxisAlignedBB#addCoord` was changed to `AxisAlignedBB#expand`. So no crash or compile error occurs when updating to 1.12 while using the 3-param `AxisAlignedBB#expand`, but this 'add-when-you-should-expand' bug just lurks for ages... This should be made into some kind of PSA... I'm sure it's in numerous mods right now.

Anyway, I've gone ahead and used the one-parameter version of `AxisAlignedBB#grow` to be concise.