### PR TITLE
disable debug output

### DIFF
--- a/src/main/java/com/mrcrayfish/furniture/blocks/BlockModernSlidingDoor.java
+++ b/src/main/java/com/mrcrayfish/furniture/blocks/BlockModernSlidingDoor.java
@@ -161,7 +161,7 @@ public class BlockModernSlidingDoor extends BlockFurniture implements IPowered
     {
         if(!worldIn.isRemote)
         {
-            System.out.println(worldIn.isBlockPowered(pos));
+            //System.out.println(worldIn.isBlockPowered(pos));
             boolean hasPower = worldIn.isBlockPowered(pos);
             if(state.getValue(TOP))
             {


### PR DESCRIPTION
Comment a line that excessively spams the server console with lines containing just true or false when players use sliding doors.