### PR TITLE
Fixed broken Modern Light crafting recipe.

### DIFF
--- a/src/main/resources/assets/cfm/recipes/modern_light.json
+++ b/src/main/resources/assets/cfm/recipes/modern_light.json
@@ -1,6 +1,6 @@
 {
     "result": {
-        "item": "cfm:modern_light",
+        "item": "cfm:modern_light_off",
         "count": 4
     },
     "pattern": [


### PR DESCRIPTION
Fixed broken recipe by correcting item ID.
Fixes #347 