### PR TITLE
Fixed broken Blue Modern Bed crafting recipe.

### DIFF
--- a/src/main/resources/assets/cfm/recipes/modern_bed_blue.json
+++ b/src/main/resources/assets/cfm/recipes/modern_bed_blue.json
@@ -1,7 +1,7 @@
 {
     "result": {
         "item": "cfm:modern_bed_bottom",
-        "data": 12
+        "data": 11
     },
     "pattern": [
         " O ",
@@ -16,7 +16,7 @@
         },
         "C": {
             "item": "minecraft:bed",
-            "data": 12
+            "data": 11
         }
     }
 }


### PR DESCRIPTION
Corrected item ID data values for both the Blue Modern Bed and Blue Bed.
Fixes #348 