### PR TITLE
Correct digital clock time

### DIFF
--- a/src/main/java/com/mrcrayfish/furniture/util/TimeUtil.java
+++ b/src/main/java/com/mrcrayfish/furniture/util/TimeUtil.java
@@ -4,7 +4,7 @@ public class TimeUtil
 {
 	public static String getFormattedTime(long ticks)
 	{
-		int hours = (int) ((Math.floor(ticks / 1000.0) + 7) % 24);
+		int hours = (int) ((Math.floor(ticks / 1000.0) + 6) % 24);
 		int minutes = (int) Math.floor((ticks % 1000) / 1000.0 * 60);
 		return String.format("%02d:%02d", hours, minutes);
 	}


### PR DESCRIPTION
Digital clocks presently display a time that is one hour ahead of the in-game server time. This will subtract that one additional hour and correct the digital clock.

This will fix #279 