### PR TITLE
Add generic constructors for (almost) all TileEntities.

### DIFF
--- a/src/main/java/com/mrcrayfish/furniture/tileentity/BedsideCabinetTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/BedsideCabinetTileEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.inventory.container.ChestContainer;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.Vec3i;
@@ -28,6 +29,15 @@ public class BedsideCabinetTileEntity extends BasicLootTileEntity
     {
         super(ModTileEntities.BEDSIDE_CABINET);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public BedsideCabinetTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
+
 
     @Override
     public int getSizeInventory()

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/CabinetTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/CabinetTileEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.inventory.container.ChestContainer;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.Vec3i;
@@ -28,6 +29,14 @@ public class CabinetTileEntity extends BasicLootTileEntity
     {
         super(ModTileEntities.CABINET);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public CabinetTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
 
     @Override
     public int getSizeInventory()

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/CoolerTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/CoolerTileEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.inventory.container.ChestContainer;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.Vec3i;
@@ -28,6 +29,15 @@ public class CoolerTileEntity extends BasicLootTileEntity
     {
         super(ModTileEntities.COOLER);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public CoolerTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
+
 
     @Override
     public int getSizeInventory()

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/CrateTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/CrateTileEntity.java
@@ -15,6 +15,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SUpdateTileEntityPacket;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
@@ -42,6 +43,15 @@ public class CrateTileEntity extends BasicLootTileEntity
     {
         super(ModTileEntities.CRATE);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public CrateTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
+
 
     @Override
     public int getSizeInventory()

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/DeskCabinetTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/DeskCabinetTileEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.inventory.container.ChestContainer;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.Vec3i;
@@ -28,6 +29,14 @@ public class DeskCabinetTileEntity extends BasicLootTileEntity
     {
         super(ModTileEntities.DESK_CABINET);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public DeskCabinetTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
 
     @Override
     public int getSizeInventory()

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/DoorMatTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/DoorMatTileEntity.java
@@ -6,6 +6,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SUpdateTileEntityPacket;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraftforge.common.util.Constants;
 
 import javax.annotation.Nullable;
@@ -21,6 +22,14 @@ public class DoorMatTileEntity extends TileEntity
     {
         super(ModTileEntities.DOOR_MAT);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public DoorMatTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
 
     public void setMessage(String message)
     {

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/FreezerTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/FreezerTileEntity.java
@@ -22,6 +22,7 @@ import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ChestTileEntity;
 import net.minecraft.tileentity.ITickableTileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.MathHelper;
@@ -103,6 +104,14 @@ public class FreezerTileEntity extends BasicLootTileEntity implements ITickableT
     {
         super(ModTileEntities.FREEZER);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public FreezerTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
 
     @Override
     public void tick()

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/FridgeTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/FridgeTileEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.inventory.container.ChestContainer;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.Vec3i;
@@ -28,6 +29,15 @@ public class FridgeTileEntity extends BasicLootTileEntity
     {
         super(ModTileEntities.FRIDGE);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public FridgeTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
+
 
     @Override
     public int getSizeInventory()

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/GrillTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/GrillTileEntity.java
@@ -22,6 +22,7 @@ import net.minecraft.network.play.server.SUpdateTileEntityPacket;
 import net.minecraft.particles.ParticleTypes;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.SoundCategory;
@@ -62,6 +63,14 @@ public class GrillTileEntity extends TileEntity implements IClearable, ITickable
     {
         super(ModTileEntities.GRILL);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public GrillTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
 
     @OnlyIn(Dist.CLIENT)
     public void setFlipping(int position)

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/KitchenDrawerTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/KitchenDrawerTileEntity.java
@@ -11,6 +11,7 @@ import net.minecraft.inventory.container.ChestContainer;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.Vec3i;
@@ -29,6 +30,14 @@ public class KitchenDrawerTileEntity extends BasicLootTileEntity
     {
         super(ModTileEntities.KITCHEN_DRAWER);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public KitchenDrawerTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
 
     @Override
     public int getSizeInventory()

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/KitchenSinkTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/KitchenSinkTileEntity.java
@@ -1,6 +1,7 @@
 package com.mrcrayfish.furniture.tileentity;
 
 import com.mrcrayfish.furniture.core.ModTileEntities;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraftforge.fluids.FluidAttributes;
 
 /**
@@ -12,4 +13,13 @@ public class KitchenSinkTileEntity extends FluidHandlerSyncedTileEntity
     {
         super(ModTileEntities.KITCHEN_SINK, FluidAttributes.BUCKET_VOLUME * 10);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public KitchenSinkTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType, FluidAttributes.BUCKET_VOLUME * 10); }
+
 }

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/MailBoxTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/MailBoxTileEntity.java
@@ -13,6 +13,7 @@ import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SUpdateTileEntityPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.ITickableTileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.common.util.Constants;
@@ -36,6 +37,14 @@ public class MailBoxTileEntity extends BasicLootTileEntity implements ITickableT
     {
         super(ModTileEntities.MAIL_BOX);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public MailBoxTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
 
     public void setId(UUID id)
     {

--- a/src/main/java/com/mrcrayfish/furniture/tileentity/TrampolineTileEntity.java
+++ b/src/main/java/com/mrcrayfish/furniture/tileentity/TrampolineTileEntity.java
@@ -6,6 +6,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SUpdateTileEntityPacket;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.util.Constants;
@@ -25,6 +26,14 @@ public class TrampolineTileEntity extends TileEntity
     {
         super(ModTileEntities.TRAMPOLINE);
     }
+
+    /**
+     * Alternative Constructor useful when reusing this class.
+     * Needed because registering tile entities requires valid blocks.
+     * @see TileEntityType
+     * @param tileEntityType : The TileEntityType you use instead.
+     */
+    public TrampolineTileEntity(TileEntityType<?> tileEntityType) { super(tileEntityType); }
 
     @Override
     public void onLoad()


### PR DESCRIPTION
This API allows to you construct Tile Entities with different TileEntityTypes.
Solves #540 
I created a generic constructor to not conflict with existing code.